### PR TITLE
Return errors if GQL did not succeed

### DIFF
--- a/apps/ec2-unattached-ebs-volumes/app.py
+++ b/apps/ec2-unattached-ebs-volumes/app.py
@@ -22,5 +22,8 @@ def lambda_handler(event, context):
 
     response = client.execute(query)
     response_json = json.loads(response)
-    volumes = response_json["data"]["ec2_volume"]["data"]
-    return [v for v in volumes if not v["attachments"]]
+    if (response_json["data"]):
+        volumes = response_json["data"]["ec2_volume"]["data"]
+        return [v for v in volumes if not v["attachments"]]
+    else:
+        return response_json["errors"]


### PR DESCRIPTION
If schema does not support query, the app will return a message that looks like the: 

[
  {
    "message": "Please verify that you gave Faros permissions to appropriate services in set up.",
    "locations": []
  },
  {
    "message": "Cannot query field 'ec2_volume' on type 'Query'. (line 2, column 15):\n              ec2_volume {\n              ^",
    "locations": [
      {
        "line": 2,
        "column": 15
      }
    ]
  }
]